### PR TITLE
Fix the error with never resolving promise

### DIFF
--- a/content/posts/2019-08-30-handling-race-conditions-in-react/index.mdx
+++ b/content/posts/2019-08-30-handling-race-conditions-in-react/index.mdx
@@ -316,7 +316,7 @@ fetch('/', { signal: abortController.signal }).then(
     // Here you can decide to handle the abortion the way you want.
     // Throwing or never resolving are valid options
     if (abortController.signal.aborted) {
-      return new Promise();
+      return new Promise(() => {});
     }
 
     return data;


### PR DESCRIPTION
`new Promise()` will not work. It will throw the `TypeError` in run time. This is the error message in Chrome:
```
Uncaught TypeError: Promise resolver undefined is not a function
```
The excerpt from the specification:
```
If IsCallable(executor) is false, throw a TypeError exception.
```
https://www.ecma-international.org/ecma-262/6.0/#sec-promise-executor